### PR TITLE
Added files for docker support

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,14 @@
+{
+    "actions": [
+        {
+            "device_name": "Stereo",
+            "action": "start_playing",
+            "command": "say 'stereo starting'"
+        },
+        {
+            "device_name": "Stereo",
+            "action": "end_playing",
+            "command": "say 'stereo stopping'"
+        }
+    ]
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  airplay-music-watcher:
+    container_name: airplay-music-watcher
+    image: airplay-music-watcher:latest
+    network_mode: host
+    volumes:
+      - ./config.json:/config/config.json
+    restart: unless-stopped
+

--- a/dockerfile
+++ b/dockerfile
@@ -15,8 +15,7 @@ COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o /airplay-music-watcher
 
 # Deploy the application binary into a lean image
-FROM gcr.io/distroless/base-debian11 AS build-release-stage
-
+FROM alpine/curl AS build-release-stage
 
 WORKDIR /
 
@@ -30,7 +29,7 @@ COPY --from=build-stage /airplay-music-watcher /airplay-music-watcher
 EXPOSE 5353
 
 # Run
-USER nonroot:nonroot
+USER root:root
 VOLUME [ "/config" ]
 
 ENTRYPOINT ["/airplay-music-watcher", "/config/config.json"]

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,39 @@
+FROM golang:1.20 AS build-stage
+
+# Set destination for COPY
+WORKDIR /
+
+# Download Go modules
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source code. Note the slash at the end, as explained in
+# https://docs.docker.com/engine/reference/builder/#copy
+COPY . ./
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux go build -o /airplay-music-watcher
+
+# Deploy the application binary into a lean image
+FROM gcr.io/distroless/base-debian11 AS build-release-stage
+
+
+WORKDIR /
+
+COPY --from=build-stage /airplay-music-watcher /airplay-music-watcher
+
+# Optional:
+# To bind to a TCP port, runtime parameters must be supplied to the docker command.
+# But we can document in the Dockerfile what ports
+# the application is going to listen on by default.
+# https://docs.docker.com/engine/reference/builder/#expose
+EXPOSE 5353
+
+# Run
+USER nonroot:nonroot
+VOLUME [ "/config" ]
+
+ENTRYPOINT ["/airplay-music-watcher", "/config/config.json"]
+
+
+


### PR DESCRIPTION
I'm running only containers on my local server and thought it could be helpful for someone else to have support for docker images on this cool project. 

I've added a dockerfile, a docker-compose.yaml and updated the documentation. What is missing is a build and publish step for the docker images to Docker Hub container registry. Right now the image needs to be build locally.